### PR TITLE
Ticket #993: Added DMOV record so it can be used via a block name

### DIFF
--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -303,3 +303,14 @@ record(stringout,"$(P):$(M)_ERROR")
 }
 
 # end
+
+# Expose the DMOV field as a PV record, so it can be access from a block
+record(ai,"$(P):$(M):DMOV")
+{
+	field(DESC, "Done move?")
+    field(SCAN, "Passive")
+    field(DTYP, "Soft Channel")
+    field(INP, "$(P):$(M).DMOV CP")
+}
+
+# end

--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -302,8 +302,6 @@ record(stringout,"$(P):$(M)_ERROR")
     field(OUT, "@errlog")
 }
 
-# end
-
 # Expose the DMOV field as a PV record, so it can be access from a block
 record(ai,"$(P):$(M):DMOV")
 {


### PR DESCRIPTION
DMOV for motor should be available so they can be accessed via a Block.

e.g.

caget %MYPVPREFIX%CS:SB:MOTOR3:DMOV

where MOTOR3 points at  IN:DEMO:MOT:MTR0103 as in the motor_waitfor config on DEMO.