### PR TITLE
Use scalcout record to avoid repeating error messages

### DIFF
--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -282,28 +282,12 @@ record(aSub,"$(P):$(M)_ERRCALC")
 
 record(stringout, "$(P):$(M)_ERRCALC_MESS")
 {
-	field(FLNK, "$(P):$(M)_ERRCALC_FAN.PROC")
-}
-
-# on success VALB above == 0 and so fanout triggers no output, VALB == 1 causes OUTA to fire
-# we want to record error messages, but not blanks on no error
-record(fanout, "$(P):$(M)_ERRCALC_FAN")
-{
-	field(SELM, "Specified")
-    field(SELL, "$(P):$(M)_ERRCALC.VALB NPP")
-	field(LNK1, "$(P):$(M)_ERROR")
-}
-
-record(scalcout, "$(P):$(M)_ERROR")
-{
-    field(INAA, "$(P):$(M)_ERRCALC.VALA NPP")
-	field(CALC, "AA")
-	field(OOPT, "On Change")
-	field(OUT, "$(P):$(M)_PERROR PP")
 }
 
 record(stringout, "$(P):$(M)_PERROR")
 {
+    field(OMSL, "closed_loop")
+    field(DOL, "$(P):$(M)_ERRCALC_MESS CP")
     field(DTYP, "stdio")
     field(OUT, "@errlog")
 }

--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -294,10 +294,16 @@ record(fanout, "$(P):$(M)_ERRCALC_FAN")
 	field(LNK1, "$(P):$(M)_ERROR")
 }
 
-record(stringout,"$(P):$(M)_ERROR")
+record(scalcout, "$(P):$(M)_ERROR")
 {
-    field(OMSL, "closed_loop")
-	field(DOL, "$(P):$(M)_ERRCALC.VALA NPP")
+    field(INAA, "$(P):$(M)_ERRCALC.VALA NPP")
+	field(CALC, "AA")
+	field(OOPT, "On Change")
+	field(OUT, "$(P):$(M)_PERROR PP")
+}
+
+record(stringout, "$(P):$(M)_PERROR")
+{
     field(DTYP, "stdio")
     field(OUT, "@errlog")
 }


### PR DESCRIPTION
To test:

Before merging, try to force motor into some sort of error state - on IMAT it seems to be hitting a hardware high limit and then the same error message gets repeatedly sent to the error log in IBEX. It might be possible with soft limits on a motor? If this can be emulated, then after merge you should only get one error. If you can't simulate multiple identical errors, just check merge doesn't stop you getting an error message   

See ISISComputingGroup/IBEX#1835
