### PR TITLE
Allow special Galil move command to be specified

### DIFF
--- a/GalilSup/Db/galil_motor_extras.req
+++ b/GalilSup/Db/galil_motor_extras.req
@@ -22,4 +22,4 @@ $(P)$(M)_OFFDELAY_SP
 $(P)$(M)_UINDEX_CMD
 $(P)$(M)_JAH_CMD
 $(P)$(M)_JAHV_SP
-
+$(P)$(M)_MOVE_CMD

--- a/GalilSup/Db/galil_motor_extras.template
+++ b/GalilSup/Db/galil_motor_extras.template
@@ -735,4 +735,15 @@ record(mbbo,"$(P):$(M)_ON_CMD")
 	field(FLNK, "$(P):$(M)_ON_STATUS")
 }
 
+## if we don't send moves in the usual way, put a string here and %f will be replaced by
+## the position requested and sent to the galil
+record(stringout,"$(P):$(M)_MOVE_CMD")
+{
+	field(DESC, "Special Motor Move cmd")
+	field(DTYP, "asynOctetWrite")
+	field(PINI, "YES")
+	field(VAL,  "")
+	field(OUT,  "@asyn($(PORT),$(ADDR))MOVE_COMMAND")
+}
+
 #end

--- a/GalilSup/src/GalilController.cpp
+++ b/GalilSup/src/GalilController.cpp
@@ -239,6 +239,7 @@ GalilController::GalilController(const char *portName, const char *address, doub
   createParam(GalilSerialNumString, asynParamOctet, &GalilSerialNum_);
 
 //Add new parameters here
+  createParam(GalilMoveCommandString, asynParamOctet, &GalilMoveCommand_);
 
   createParam(GalilCommunicationErrorString, asynParamInt32, &GalilCommunicationError_);
 
@@ -485,7 +486,10 @@ void GalilController::setParamDefaults(void)
   setStringParam(1, GalilCoordSysMotors_, "");
   //Put all motors in spmg go mode
   for (i = 0; i < MAX_GALIL_AXES + MAX_GALIL_CSAXES; i++)
+  {
 	setIntegerParam(i, GalilMotorStopGo_, 3);
+    setStringParam(i, GalilMoveCommand_, "");
+  }
   //Output compare is off
   for (i = 0; i < 2; i++)
 	setIntegerParam(i, GalilOutputCompareAxis_, 0);

--- a/GalilSup/src/GalilController.h
+++ b/GalilSup/src/GalilController.h
@@ -138,6 +138,7 @@
 
 #define GalilEthAddrString	  	"CONTROLLER_ETHADDR"
 #define GalilSerialNumString	  	"CONTROLLER_SERIALNUM"
+#define GalilMoveCommandString	"MOVE_COMMAND"
 
 /* For each digital input, we maintain a list of motors, and the state the input should be in*/
 /* To disable the motor */
@@ -306,7 +307,8 @@ protected:
   int GalilEthAddr_;
   int GalilSerialNum_;
 //Add new parameters here
-
+  int GalilMoveCommand_;
+  
   int GalilCommunicationError_;
   #define LAST_GALIL_PARAM GalilCommunicationError_
 


### PR DESCRIPTION
New string PVs named like  MTR0101_MOVE_CMD   that if set
will be used instead of commands like  PA/PR to
do the move on an axis. If the string contains a single %f
instance it will be replaced with the requested raw position

If the motor readback is not being done by the galil driver,
then you should make sure auto on/off of the motor is disabled

See ISISComputingGroup/IBEX#1990
