### PR TITLE
Add gmc homeing files that do nothing

### DIFF
--- a/GalilSup/Db/Makefile
+++ b/GalilSup/Db/Makefile
@@ -34,7 +34,9 @@ GMC += galil_Default_Footer.gmc  galil_Default_Header.gmc  galil_Home_ForwLimit.
 GMC += galil_Home_Home.gmc  galil_Home_Home+FIneg.gmc  galil_Home_Home+FIpos.gmc  galil_Home_RevLimit.gmc
 GMC += galil_Home_RevLimit_Home.gmc  galil_Piezo_Home.gmc  galil_Home_ForwLimit+FIneg.gmc  galil_Home_RevLimit+FIpos.gmc
 GMC += galil_Home_Pin_Hole_Selector.gmc  galil_Home_Thread.gmc  galil_Home_Dummy_Axis.gmc
-GMC += galil_Home_FIpos.gmc galil_Home_FIneg.gmc galil_Muon_Slits.gmc
+GMC += galil_Home_FIpos.gmc galil_Home_FIneg.gmc galil_Muon_Slits.gmc 
+# Dummy routines mainly used for testing
+GMC += galil_Home_Dummy_Do_Nothing.gmc galil_Home_Dummy_Power_Light.gmc
 
 include $(TOP)/configure/RULES
 #----------------------------------------

--- a/GalilSup/Db/Makefile
+++ b/GalilSup/Db/Makefile
@@ -30,6 +30,7 @@ DB += galil_userdef_records8.template
 # galil_Muon_Slits is a routine used by the Muons
 
 # Example galil code templates
+GMC += ReadMe.md
 GMC += galil_Default_Footer.gmc  galil_Default_Header.gmc  galil_Home_ForwLimit.gmc  galil_Home_ForwLimit_Home.gmc
 GMC += galil_Home_Home.gmc  galil_Home_Home+FIneg.gmc  galil_Home_Home+FIpos.gmc  galil_Home_RevLimit.gmc
 GMC += galil_Home_RevLimit_Home.gmc  galil_Piezo_Home.gmc  galil_Home_ForwLimit+FIneg.gmc  galil_Home_RevLimit+FIpos.gmc

--- a/GalilSup/Db/ReadMe.md
+++ b/GalilSup/Db/ReadMe.md
@@ -1,0 +1,42 @@
+# GMC Files Read Me 
+
+The GMC files in his directory are for code sent to the Galil controller. The gallil files mostly control homing behaviour they are:
+
+
+## Homing Routines
+
+File                             | What                                                              | Must have encoder
+-------------------------------- | ----------------------------------------------------------------- | -----------------
+galil_Home_Dummy_Axis.gmc        | Jogs a axis for 15s **USE ONLY IF YOU KNOW WHAT YOU ARE DOING**   | no 
+galil_Home_Dummy_Do_Nothing.gmc  | Wait for 100ms and report homed                                   | no
+galil_Home_Dummy_Power_Light.gmc | Turn power light on (servo here), wait 100ms and report homed     | no
+galil_Home_FIneg.gmc             | Find encoder index in negative direction                          | yes
+galil_Home_FIpos.gmc             | Find encoder index in positive direction                          | yes
+galil_Home_ForwLimit.gmc         | Find forward limit switch                                         | no
+galil_Home_ForwLimit_Home.gmc    |  Find forward limit switch, find home datum switch                | no
+galil_Home_ForwLimit+FIneg.gmc   | Find forward limit switch, find encoder index                     | yes
+galil_Home_Home.gmc              | Find home datum switch                                            | no
+galil_Home_Home+FIneg.gmc        | Find home datum switch, find encoder index in negative direction  | yes
+galil_Home_Home+FIpos.gmc        | Find home datum switch, find encoder index in positive direction  | yes
+galil_Home_Pin_Hole_Selector.gmc | IMAT homing for pin hole selector                                 | N/A
+galil_Home_RevLimit.gmc          | Find reverse limit switch                                         | no
+galil_Home_RevLimit_Home.gmc     | Find reverse limit switch, find home datum switch                 | no
+galil_Home_RevLimit+FIpos.gmc    | Find reverse limit switch, find encoder index                     | yes
+galil_Home_Thread.gmc            | Monitor galil threads until complete                              | N/A
+galil_Piezo_Home.gmc             | Find edge, find edge in opposite direction; good for piezo motors | no
+
+
+## Other Files
+
+File                             | What                                                              | Must have encoder
+-------------------------------- | ----------------------------------------------------------------- | -----------------
+galil_Default_Footer.gmc         | Deal with command errors, tcp errors and limit switches           | N/A
+galil_Default_Header.gmc         | Setup variables,  run homeA command in thread 1 and runs forever  | N/A
+galil_Muon_Slits.gmc             | Drive to analogue value for muon instrument slits                 | N/A
+
+
+## Notes
+
+An encoder index is a pulse at a position as the motor moves across it
+A datum is a switch it switches on or off at the position depending on the direction of travel.
+There may be multiple indexes on an encoder

--- a/GalilSup/Db/galil_Home_Dummy_Do_Nothing.gmc
+++ b/GalilSup/Db/galil_Home_Dummy_Do_Nothing.gmc
@@ -1,0 +1,35 @@
+NO*****************AXIS ${AXIS}********************
+NO*************Home_Dummy_Do_Nothing***************
+#HOME${AXIS}
+IF (home${AXIS}=1)
+    inhome${AXIS}=1
+	IF ((home${AXIS}=1) & (hjog${AXIS}=0))
+	    slimfl${AXIS}=_FL${AXIS};FL${AXIS}=2147483647
+		slimbl${AXIS}=_BL${AXIS};BL${AXIS}=-2147483648
+		hjog${AXIS}=1
+	ENDIF
+	IF ((_LR${AXIS}=0) & (_LF${AXIS}=0) & (home${AXIS}=1))
+		home${AXIS}=0;MG "home${AXIS}", home${AXIS};ENDIF
+	IF ((hjog${AXIS}=1) & (_BG${AXIS}=1) & (home${AXIS}=1))
+		ST${AXIS};ENDIF
+	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
+		WT100;hjog${AXIS}=2
+	ENDIF
+	IF ((hjog${AXIS}>=2) & (_BG${AXIS}=0) & (home${AXIS}=1))
+		hjog${AXIS}=hjog${AXIS}+1
+	ENDIF
+	IF ((hjog${AXIS}=5) & (_BG${AXIS}=0) & (home${AXIS}=1))
+		hjog${AXIS}=0;home${AXIS}=0;homed${AXIS}=1;MO${AXIS}
+		MG "home${AXIS}", home${AXIS};MG "homed${AXIS}", homed${AXIS}
+	ENDIF
+ELSE
+	hjog${AXIS}=0
+ENDIF
+IF ((home${AXIS}=0) & (inhome${AXIS}=1))
+    FL${AXIS}=slimfl${AXIS}
+	BL${AXIS}=slimbl${AXIS}
+	inhome${AXIS}=0
+ENDIF
+IF (mlock=1)
+	II ,,dpon,dvalues
+ENDIF

--- a/GalilSup/Db/galil_Home_Dummy_Power_Light.gmc
+++ b/GalilSup/Db/galil_Home_Dummy_Power_Light.gmc
@@ -1,0 +1,35 @@
+NO*****************AXIS ${AXIS}********************
+NO************Home_Dummy_Power_Light***************
+#HOME${AXIS}
+IF (home${AXIS}=1)
+    inhome${AXIS}=1
+	IF ((home${AXIS}=1) & (hjog${AXIS}=0))
+	    slimfl${AXIS}=_FL${AXIS};FL${AXIS}=2147483647
+		slimbl${AXIS}=_BL${AXIS};BL${AXIS}=-2147483648
+		hjog${AXIS}=1
+	ENDIF
+	IF ((_LR${AXIS}=0) & (_LF${AXIS}=0) & (home${AXIS}=1))
+		home${AXIS}=0;MG "home${AXIS}", home${AXIS};ENDIF
+	IF ((hjog${AXIS}=1) & (_BG${AXIS}=1) & (home${AXIS}=1))
+		ST${AXIS};ENDIF
+	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
+		SH${AXIS};WT100;hjog${AXIS}=2
+	ENDIF
+	IF ((hjog${AXIS}>=2) & (_BG${AXIS}=0) & (home${AXIS}=1))
+		hjog${AXIS}=hjog${AXIS}+1
+	ENDIF
+	IF ((hjog${AXIS}=5) & (_BG${AXIS}=0) & (home${AXIS}=1))
+		hjog${AXIS}=0;home${AXIS}=0;homed${AXIS}=1;MO${AXIS}
+		MG "home${AXIS}", home${AXIS};MG "homed${AXIS}", homed${AXIS}
+	ENDIF
+ELSE
+	hjog${AXIS}=0
+ENDIF
+IF ((home${AXIS}=0) & (inhome${AXIS}=1))
+    FL${AXIS}=slimfl${AXIS}
+	BL${AXIS}=slimbl${AXIS}
+	inhome${AXIS}=0
+ENDIF
+IF (mlock=1)
+	II ,,dpon,dvalues
+ENDIF


### PR DESCRIPTION
For ticket https://github.com/ISISComputingGroup/IBEX/issues/2313.

Acceptance criteria:
 - Programs can be loaded in. 
 - Home finished without 

    ```
    sevr=major Homing timed out after 3.500000: BGA=0.000000 SCA=4.000000
    sevr=major A Homing timed out
    ```
