### PR TITLE
Ticket 2535: Add GMC file for collimator

### DIFF
--- a/GalilSup/Db/Makefile
+++ b/GalilSup/Db/Makefile
@@ -36,6 +36,8 @@ GMC += galil_Home_Home.gmc  galil_Home_Home+FIneg.gmc  galil_Home_Home+FIpos.gmc
 GMC += galil_Home_RevLimit_Home.gmc  galil_Piezo_Home.gmc  galil_Home_ForwLimit+FIneg.gmc  galil_Home_RevLimit+FIpos.gmc
 GMC += galil_Home_Pin_Hole_Selector.gmc  galil_Home_Thread.gmc  galil_Home_Dummy_Axis.gmc
 GMC += galil_Home_FIpos.gmc galil_Home_FIneg.gmc galil_Muon_Slits.gmc 
+# Device specific routines
+GMC += galil_Oscillating_Collimator.gmc
 # Dummy routines mainly used for testing
 GMC += galil_Home_Dummy_Do_Nothing.gmc galil_Home_Dummy_Power_Light.gmc
 

--- a/GalilSup/Db/Makefile
+++ b/GalilSup/Db/Makefile
@@ -37,7 +37,7 @@ GMC += galil_Home_RevLimit_Home.gmc  galil_Piezo_Home.gmc  galil_Home_ForwLimit+
 GMC += galil_Home_Pin_Hole_Selector.gmc  galil_Home_Thread.gmc  galil_Home_Dummy_Axis.gmc
 GMC += galil_Home_FIpos.gmc galil_Home_FIneg.gmc galil_Muon_Slits.gmc 
 # Device specific routines
-GMC += galil_Oscillating_Collimator.gmc
+GMC += galil_Oscillating_Collimator.gmc galil_Oscillating_Collimator_Merlin.gmc
 # Dummy routines mainly used for testing
 GMC += galil_Home_Dummy_Do_Nothing.gmc galil_Home_Dummy_Power_Light.gmc
 

--- a/GalilSup/Db/galil_Oscillating_Collimator.gmc
+++ b/GalilSup/Db/galil_Oscillating_Collimator.gmc
@@ -4,13 +4,13 @@
 '***********************************
 #HOMER
 '*******STEP 1 - Retract Motor******
-mode="I"
+mode="0"
 count=0
 MT~a=2
 DC~a=1024;AC~a=1024;SH~a
 JP #HOME, @IN[7]=1
 JG~a=250
-mode="H"
+mode="1"
 BG~a
 #INI
 JP #INI, @IN[7]<>1
@@ -20,7 +20,7 @@ AM~a
 '
 #HOME
 '*******STEP 2 - Find Analogue Home*******
-mode="H"
+mode="1"
 AC~a=67107840;DC~a=1024;JG~a=-250
 BG~a
 #HEO
@@ -41,7 +41,7 @@ WT1000
 '
 #OSCILSU
 '****Step 3 - Oscillation Setup*******
-mode="O"
+mode="2"
 count=0
 AC~a=accel;DC~a=accel;SP~a=vel
 SH~a

--- a/GalilSup/Db/galil_Oscillating_Collimator.gmc
+++ b/GalilSup/Db/galil_Oscillating_Collimator.gmc
@@ -1,0 +1,64 @@
+'************LET Collimator*********
+'***********************************
+'DETERMINE INITIAL POSITION
+'***********************************
+#HOMER
+'*******STEP 1 - Retract Motor******
+mode="I"
+count=0
+MT~a=2
+DC~a=1024;AC~a=1024;SH~a
+JP #HOME, @IN[7]=1
+JG~a=250
+mode="H"
+BG~a
+#INI
+JP #INI, @IN[7]<>1
+WT 100
+ST~a
+AM~a
+'
+#HOME
+'*******STEP 2 - Find Analogue Home*******
+mode="H"
+AC~a=67107840;DC~a=1024;JG~a=-250
+BG~a
+#HEO
+JP #HEO, @IN[7]=1
+ST~a
+AM~a
+WT100
+'
+AC~a=1024;DC~a= 67107840;JG~a= 20
+BG~a
+#HR
+JP #HR, @IN[7]<>1
+ST~a
+AM~a
+WT1000
+DP~a=0
+WT1000
+'
+#OSCILSU
+'****Step 3 - Oscillation Setup*******
+mode="O"
+count=0
+AC~a=accel;DC~a=accel;SP~a=vel
+SH~a
+PA~a=-dist/2
+MC~a
+'
+#OSCIL
+'****Step 4 - Oscillations************
+time1=TIME
+PA~a=dist/2;BG~a;
+#CHECK1
+JP #CHECK1, @IN[7]=0
+check=_RP~a
+AM~a
+PA~a=-dist/2;BG~a;AM~a
+count=count+1
+time=TIME-time1
+'JP #HOMER, check>125
+JP#OSCIL
+EN

--- a/GalilSup/Db/galil_Oscillating_Collimator.gmc
+++ b/GalilSup/Db/galil_Oscillating_Collimator.gmc
@@ -4,13 +4,13 @@
 '***********************************
 #HOMER
 '*******STEP 1 - Retract Motor******
-mode="0"
+mode=0
 count=0
 MT~a=2
 DC~a=1024;AC~a=1024;SH~a
 JP #HOME, @IN[7]=1
 JG~a=250
-mode="1"
+mode=1
 BG~a
 #INI
 JP #INI, @IN[7]<>1
@@ -20,7 +20,7 @@ AM~a
 '
 #HOME
 '*******STEP 2 - Find Analogue Home*******
-mode="1"
+mode=1
 AC~a=67107840;DC~a=1024;JG~a=-250
 BG~a
 #HEO
@@ -41,7 +41,7 @@ WT1000
 '
 #OSCILSU
 '****Step 3 - Oscillation Setup*******
-mode="2"
+mode=2
 count=0
 AC~a=accel;DC~a=accel;SP~a=vel
 SH~a

--- a/GalilSup/Db/galil_Oscillating_Collimator_Merlin.gmc
+++ b/GalilSup/Db/galil_Oscillating_Collimator_Merlin.gmc
@@ -1,0 +1,69 @@
+'************MERLIN Collimator*********
+'***********************************
+'DETERMINE INITIAL POSITION
+'***********************************
+#HOMER
+'*******STEP 1 - Retract Motor******
+mode="I"
+count=0
+MT~a=2
+DC~a=1024;AC~a=1024;SH~a
+JP #HOME, @IN[6]=1
+JG~a=250
+mode="H"
+BG~a
+#INI
+JP #INI, @IN[6]<>1
+WT 100
+ST~a
+AM~a
+'
+#HOME
+'*******STEP 2 - Find Gigital Home*******
+mode="H"
+AC~a=67107840;DC~a=1024;JG~a=-250
+SH~a;BG~a
+#HEO
+JP #HEO, @IN[6]=1
+ST~a
+AM~a
+WT100
+'
+AC~a=1024;DC~a= 67107840;JG~a= 20
+SH~a;BG~a
+#HR
+JP #HR, @IN[6]<>1
+ST~a
+AM~a
+WT1000
+DP~a=-200
+PA~a=0
+SH~a
+SP~a=1024
+BG~a
+AM~a
+WT1000
+'
+#OSCILSU
+'****Step 3 - Oscillation Setup*******
+mode="O"
+count=0
+AC~a=accel;DC~a=accel;SP~a=vel
+SH~a
+PA~a=-dist/2
+MC~a
+'
+#OSCIL
+'****Step 4 - Oscillations************
+time1=TIME
+SH~a;PA~a=dist/2;BG~a;
+#CHECK1
+JP #CHECK1, @IN[6]=0
+check=_RP~a
+AM~a
+SH~a;PA~a=-dist/2;BG~a;AM~a
+count=count+1
+time=TIME-time1
+'JP #HOMER, check>125
+JP#OSCIL
+EN

--- a/GalilSup/src/GalilController.cpp
+++ b/GalilSup/src/GalilController.cpp
@@ -3293,7 +3293,7 @@ void GalilController::GalilStartController(char *code_file, int burn_program, in
 			{
 			
 			// Only try and start thread 0 if it isn't already running
-			if (checkGalilThread(0))
+			if (!checkGalilThread(0))
 			{
 				sprintf(cmd_, "XQ 0,0");
 				if (writeReadController(functionName) != asynSuccess)

--- a/GalilSup/src/GalilController.cpp
+++ b/GalilSup/src/GalilController.cpp
@@ -3007,36 +3007,36 @@ bool GalilController::checkGalilThreads()
 /*--------------------------------------------------------------*/
 /* Find and replace text in string                              */
 /*--------------------------------------------------------------*/
-string GalilController::findReplace(string s, const string &toReplace, const string &replaceWith)
+void GalilController::findReplace(string& s, const string &toReplace, const string &replaceWith)
 {
 	while(s.find(toReplace) != std::string::npos) {
-		s = s.replace(s.find(toReplace), toReplace.length(), replaceWith);
+		s.replace(s.find(toReplace), toReplace.length(), replaceWith);
 	}
-	return s;
 }
 
 /*--------------------------------------------------------------*/
 /* Remove non-functional elements from the code                 */
 /*--------------------------------------------------------------*/
-string GalilController::compressCode(string code){
-	code = findReplace(code, "\r ", "");
+void GalilController::compressCode(string& code){
+	findReplace(code, "\r ", "");
 	// Tabs to space
-	code = findReplace(code, "\t", "    ");
+	findReplace(code, "\t", "    ");
 	// Trailing whitespace
-	code = findReplace(code, " \n", "\n");
+	findReplace(code, " \n", "\n");
 	// Leading whitespace
-	code = findReplace(code, "\n ", "\n");
+	findReplace(code, "\n ", "\n");
 	// Blank lines
-	code = findReplace(code, "\n\n", "\n");
-	return code;
+	findReplace(code, "\n\n", "\n");
 }
 
 /*--------------------------------------------------------------*/
 /* Compare old code to new code                                 */
 /*--------------------------------------------------------------*/
-int GalilController::compareCode(const string& dc, const string& uc)
+int GalilController::compareCode(string dc, string uc)
 {
-	return compressCode(dc).compare(compressCode(uc));
+	compressCode(dc);
+	compressCode(uc);
+	return dc.compare(uc);
 }
 
 /*--------------------------------------------------------------*/

--- a/GalilSup/src/GalilController.cpp
+++ b/GalilSup/src/GalilController.cpp
@@ -3032,6 +3032,48 @@ bool GalilController::checkGalilThreads()
 			}
             return result;
 }
+
+/*--------------------------------------------------------------*/
+/* Should just remove leading and trailing whitespace from      */
+/* each line of the string. For practical purposes though       */
+/* just removing all white space allows for testing functional  */
+/* equivalence.                                                 */
+/*--------------------------------------------------------------*/
+string GalilController::trimWhitespace(string s)
+{
+	s = findReplace(s, " ", "");
+	s = findReplace(s, "\t", "");
+	return s;
+}
+
+/*--------------------------------------------------------------*/
+/* Find and replace text in string  */
+/*--------------------------------------------------------------*/
+string GalilController::findReplace(string s, const string &toReplace, const string &replaceWith)
+{
+	while(s.find(toReplace) != std::string::npos) {
+		s = s.replace(s.find(toReplace), toReplace.length(), replaceWith);
+	}
+	return s;
+}
+
+/*--------------------------------------------------------------*/
+/* Remove non-functional elements from the code   */
+/*--------------------------------------------------------------*/
+string GalilController::compressCode(string s){
+	code = trimWhitespace(code);
+	code = findReplace(code, "\r", "");
+	return code;
+}
+
+/*--------------------------------------------------------------*/
+/* Compare old code to new code   */
+/*--------------------------------------------------------------*/
+int GalilController::compareCode(const string& dc, const string& uc)
+{
+	return compressCode(dc).compare(compressCode(uc));
+}
+
 /*--------------------------------------------------------------*/
 /* Start the card requested by user   */
 /*--------------------------------------------------------------*/
@@ -3124,7 +3166,7 @@ void GalilController::GalilStartController(char *code_file, int burn_program, in
 		dc.erase (std::remove(dc.begin(), dc.end(), '\r'), dc.end());
 
 		/*If code we wish to download differs from controller current code then download the new code*/
-		if (dc.compare(uc) != 0 && dc.compare("") != 0)
+		if (compareCode(dc, uc) && dc.compare("") != 0)
 			{
 			//Change \n to \r (Galil Communications Library expects \r separated lines)
 			std::replace(dc.begin(), dc.end(), '\n', '\r');

--- a/GalilSup/src/GalilController.cpp
+++ b/GalilSup/src/GalilController.cpp
@@ -3291,9 +3291,14 @@ void GalilController::GalilStartController(char *code_file, int burn_program, in
 		//Its assumed that thread 0 starts any other required threads on controller
 		if ((int)uc.length()>2)
 			{
-			sprintf(cmd_, "XQ 0,0");
-			if (writeReadController(functionName) != asynSuccess)
-				errlogPrintf("Thread 0 failed to start on model %s address %s\n\n",model_, address_);
+			
+			// Only try and start thread 0 if it isn't already running
+			if (checkGalilThread(0))
+			{
+				sprintf(cmd_, "XQ 0,0");
+				if (writeReadController(functionName) != asynSuccess)
+					errlogPrintf("Thread 0 failed to start on model %s address %s\n\n",model_, address_);
+			}
 					
 			epicsThreadSleep(1);
 			

--- a/GalilSup/src/GalilController.cpp
+++ b/GalilSup/src/GalilController.cpp
@@ -3034,20 +3034,20 @@ bool GalilController::checkGalilThreads()
 }
 
 /*--------------------------------------------------------------*/
-/* Should just remove leading and trailing whitespace from      */
-/* each line of the string. For practical purposes though       */
-/* just removing all white space allows for testing functional  */
-/* equivalence.                                                 */
+/* Remove tabs, leading and trailing white space                */
 /*--------------------------------------------------------------*/
 string GalilController::trimWhitespace(string s)
 {
-	s = findReplace(s, " ", "");
-	s = findReplace(s, "\t", "");
+	s = findReplace(s, "\t", "    ");
+	s = findReplace(s, " \r", "\r");
+	s = findReplace(s, "\r ", "\r");
+	s = findReplace(s, " \n", "\n");
+	s = findReplace(s, "\n ", "\n");
 	return s;
 }
 
 /*--------------------------------------------------------------*/
-/* Find and replace text in string  */
+/* Find and replace text in string                              */
 /*--------------------------------------------------------------*/
 string GalilController::findReplace(string s, const string &toReplace, const string &replaceWith)
 {
@@ -3058,16 +3058,16 @@ string GalilController::findReplace(string s, const string &toReplace, const str
 }
 
 /*--------------------------------------------------------------*/
-/* Remove non-functional elements from the code   */
+/* Remove non-functional elements from the code                 */
 /*--------------------------------------------------------------*/
-string GalilController::compressCode(string s){
-	code = trimWhitespace(code);
+string GalilController::compressCode(string code){
 	code = findReplace(code, "\r", "");
+	code = trimWhitespace(code);
 	return code;
 }
 
 /*--------------------------------------------------------------*/
-/* Compare old code to new code   */
+/* Compare old code to new code                                 */
 /*--------------------------------------------------------------*/
 int GalilController::compareCode(const string& dc, const string& uc)
 {
@@ -3075,7 +3075,7 @@ int GalilController::compareCode(const string& dc, const string& uc)
 }
 
 /*--------------------------------------------------------------*/
-/* Start the card requested by user   */
+/* Start the card requested by user                             */
 /*--------------------------------------------------------------*/
 void GalilController::GalilStartController(char *code_file, int burn_program, int display_code, unsigned thread_mask)
 {

--- a/GalilSup/src/GalilController.h
+++ b/GalilSup/src/GalilController.h
@@ -149,7 +149,7 @@ struct Galilmotor_enables {
 
 class GalilController : public asynMotorController {
 public:
-  GalilController(const char *portName, const char *address, double updatePeriod);
+  GalilController(const char *portName, const char *address, double updatePeriod, int quiet_start);
   
   /* These are the methods that we override from asynMotorController */
   asynStatus poll(void);
@@ -185,7 +185,7 @@ public:
   //asynStatus readbackProfile();
 
   /* These are the methods that are new to this class */
-  void GalilStartController(char *code_file, int eeprom_write, int display_code, unsigned thread_mask, int quiet_start);
+  void GalilStartController(char *code_file, int eeprom_write, int display_code, unsigned thread_mask);
   void connectManager(void);
   void connect(void);
   void disconnect(void);
@@ -364,6 +364,7 @@ private:
   
   void stopThreads();
   void stopAxes();
+  int quiet_start_;
 
 					//Stores the motor enable disable interlock digital IO setup, only first 8 digital in ports supported
   struct Galilmotor_enables motor_enables_[8];

--- a/GalilSup/src/GalilController.h
+++ b/GalilSup/src/GalilController.h
@@ -357,6 +357,11 @@ private:
 
   char cmd_[MAX_GALIL_STRING_SIZE];     //holds the assembled Galil cmd string
   char resp_[MAX_GALIL_STRING_SIZE];    //Response from Galil controller
+  
+  static int compareCode(const std::string& dc, const std::string& uc);
+  static std::string compressCode(std::string s);
+  static std::string findReplace(std::string s, const std::string& toFind, const std::string& toReplace);
+  static std::string trimWhitespace(std::string s);
 
 					//Stores the motor enable disable interlock digital IO setup, only first 8 digital in ports supported
   struct Galilmotor_enables motor_enables_[8];

--- a/GalilSup/src/GalilController.h
+++ b/GalilSup/src/GalilController.h
@@ -358,9 +358,9 @@ private:
   char cmd_[MAX_GALIL_STRING_SIZE];     //holds the assembled Galil cmd string
   char resp_[MAX_GALIL_STRING_SIZE];    //Response from Galil controller
   
-  static int compareCode(const std::string& dc, const std::string& uc);
-  static std::string compressCode(std::string s);
-  static std::string findReplace(std::string s, const std::string& toFind, const std::string& toReplace);
+  static int compareCode(std::string dc, std::string uc);
+  static void compressCode(std::string& s);
+  static void findReplace(std::string& s, const std::string& toFind, const std::string& toReplace);
   
   void stopThreads();
   void stopAxes();

--- a/GalilSup/src/GalilController.h
+++ b/GalilSup/src/GalilController.h
@@ -185,7 +185,7 @@ public:
   //asynStatus readbackProfile();
 
   /* These are the methods that are new to this class */
-  void GalilStartController(char *code_file, int eeprom_write, int display_code, unsigned thread_mask);
+  void GalilStartController(char *code_file, int eeprom_write, int display_code, unsigned thread_mask, int quiet_start);
   void connectManager(void);
   void connect(void);
   void disconnect(void);
@@ -361,7 +361,9 @@ private:
   static int compareCode(const std::string& dc, const std::string& uc);
   static std::string compressCode(std::string s);
   static std::string findReplace(std::string s, const std::string& toFind, const std::string& toReplace);
-  static std::string trimWhitespace(std::string s);
+  
+  void stopThreads();
+  void stopAxes();
 
 					//Stores the motor enable disable interlock digital IO setup, only first 8 digital in ports supported
   struct Galilmotor_enables motor_enables_[8];


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/2535

Add support for the LET oscillating collimator. This Galil program is intended to be loaded at startup. It is a copy of the one found in LabView Modules

I've added the following functionality to the Galil driver:

- I've improved the code that decides whether or not to upload the new code. Previously, the check to see whether the scripts had changed ignored whitespace formatting done by the Galil. This has been improved to more accurately decide whether the uploaded and downloaded codes are different. To test this, start the Galil with some startup setup (see motorExtensions PR for example). You should see in the IOC log a message along the lines of "Code transferred...". Restart the IOC and this time that message should not appear
- I've added an input argument to the GalilController constructor. If you add the 4th argument to be 1 then it starts in "quiet" mode. This mode will not stop the threads and axes if the code has not changed. In this mode, you should be able to start the oscillating collimator, restart the IOC, and the collimator program should still be running. Without this mode switched on, the Galil startup process should be unchanged from currently.