### PR TITLE
Ticket2785: Added MISS and RCNT to archive

### DIFF
--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -56,7 +56,7 @@ grecord(motor,"$(P):$(M)")
 	field(ICOF,"$(ICOF)")
 	field(DCOF,"$(DCOF)")
 	field(HLSV,"MINOR")
-	info(archive,"0.02 VAL RBV DVAL OFF MSTA DIR CNEN MOVN DMOV")
+	info(archive,"0.02 VAL RBV DVAL OFF MSTA DIR CNEN MOVN DMOV MISS RCNT")
 	info(alarm,"Motors")
 }
 


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/2785

To test:
* Rebuild this module
* Rebuild the Galil IOC module
* Start your instrument
* Start up a Galil
* Go to http://localhost:4812/group?name=INST and confirm that the MISS and RCNT fields of the started motor are there