### PR TITLE
Restart Galil homing threads

### DIFF
--- a/GalilSup/src/GalilAxis.cpp
+++ b/GalilSup/src/GalilAxis.cpp
@@ -582,8 +582,21 @@ asynStatus GalilAxis::home(double minVelocity, double maxVelocity, double accele
   // check homing thread is available
   if ( !pC_->checkGalilThreads() )
   {
-      errlogPrintf("Cannot start homing as galil threads are not running");
-      return asynError;
+  errlogPrintf("Galil home threads are not running. Attempting to restart homing threads.\n");
+  sprintf(pC_->cmd_, "HX0;HX1");
+  pC_->writeReadController(functionName);
+  sprintf(pC_->cmd_, "XQ 0,0");
+  pC_->writeReadController(functionName);
+  epicsThreadSleep(.2);
+  if ( !pC_->checkGalilThreads() )
+  {
+  errlogPrintf("Unable to start Galil homing threads.\n");
+  return asynError;
+  }
+  else
+  {
+  errlogPrintf("Galil homing threads restarted successfully.\n");
+  }
   }
   
   //Check velocity and wlp protection


### PR DESCRIPTION
Ticket Reference : https://github.com/ISISComputingGroup/IBEX/issues/2742

1. Connect up ioc to Galil. This will start the program threads in the Galil. This can be done using C:\Instrument\Apps\EPICS\support\galil\master\iocBoot\iocGalilTest\runioc.bat st.cmd
2. Issue : caput "MYPVPREFIX":MOT:DMC01:SEND_CMD_STR "AB0". This should stop the Galil threads.
3. Issue : caput "MYPVPREFIX":MOT:MTR0101.HOMF 1". Request home of an axis.
4. Look in the ioc window and confirm that there is a message saying the thread/threads are not running, trying to restart and confirmed restart.

If needed, to monitor the Galil threads independently, use a hyperterminal connection to the office Galil - this is connected to the MOXA in the office - baud rate 115200, no flow control. Issue the commands "HX 0" and "HX 1" to stop the threads. Issue "MG_XQ0" and MG_XQ1" to read the thread state "-1.000" means not running. Any other number means the thread is executing.