### PR TITLE
Ticket 2607: Galil specific OPI parameters

### DIFF
--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -305,7 +305,7 @@ record(ai,"$(P):$(M):DMOV")
 
 record(ao, "$(P):$(M):INV_MRES")
 {
-	field(DESC, "Set the motor resolution in steps per EGU")
+	field(DESC, "Set the motor res in steps per EGU")
 	field(FLNK, "$(P):$(M):INV_MRES:SP_CALC")
 	field(PREC, "3")
 }

--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -301,4 +301,52 @@ record(ai,"$(P):$(M):DMOV")
     field(INP, "$(P):$(M).DMOV CP")
 }
 
+# Allow setting MRES/ERES as inverse
+
+record(ao, "$(P):$(M):INV_MRES")
+{
+	field(DESC, "Set the motor resolution in steps per EGU")
+	field(FLNK, "$(P):$(M):INV_MRES:SP_CALC")
+	field(PREC, "3")
+}
+
+record(calcout, "$(P):$(M):INV_MRES:SP_CALC")
+{
+	field(INPA, "$(P):$(M):INV_MRES")
+	field(CALC, "1/A")
+	field(OUT, "$(P):$(M).MRES")
+	field(OOPT, "On Change")
+}
+
+record(calcout, "$(P):$(M):INV_MRES_CALC")
+{
+	field(INPA, "$(P):$(M).MRES CP")
+	field(CALC, "1/A")
+	field(OUT, "$(P):$(M):INV_MRES PP")
+	field(OOPT, "On Change")
+}
+
+record(ao, "$(P):$(M):INV_ERES")
+{
+	field(DESC, "Set the encoder res in steps per EGU")
+	field(FLNK, "$(P):$(M):INV_ERES:SP_CALC")
+	field(PREC, "3")
+}
+
+record(calcout, "$(P):$(M):INV_ERES:SP_CALC")
+{
+	field(INPA, "$(P):$(M):INV_ERES")
+	field(CALC, "1/A")
+	field(OUT, "$(P):$(M).ERES")
+	field(OOPT, "On Change")
+}
+
+record(calcout, "$(P):$(M):INV_ERES_CALC")
+{
+	field(INPA, "$(P):$(M).ERES CP")
+	field(CALC, "1/A")
+	field(OUT, "$(P):$(M):INV_ERES PP")
+	field(OOPT, "On Change")
+}
+
 # end


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/2607. Added parameters for setting motor resolution and encoder resolution in the inverse way (i.e. steps per unit).

To test:
* Confirm that the INV_MRES initialises with the inverse of MRES
* Confirm that when the MRES is set then the INV_MRES updates
* Confirm that when INV_MRES is set the MRES is set
* Same for ERES