### PR TITLE
Ticket2789 motor access security

### DIFF
--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -25,6 +25,17 @@
 # 800 Blackburn Road, Clayton, Victoria 3168, Australia.
 #
 
+record(scalcout, "$(P):$(M):MANAGERMODE")
+{
+    field(ASG, "READONLY")
+    field(DESC, "Non-zero if manager is required for this IOC")
+    field(PINI, "YES")
+    field(INPA, "$(PVPREFIX)CS:MANAGER CP")
+    field(BB, "$(ASG)")
+    field(CALC, "A = 0 && BB = 'MANAGER'")
+    field(OOPT, "Every Time")
+}
+
 grecord(motor,"$(P):$(M)")
 {
 	field(ASG, "$(ASG=DEFAULT)")

--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -27,6 +27,7 @@
 
 grecord(motor,"$(P):$(M)")
 {
+	field(ASG, "$(ASG=DEFAULT)")
 	field(DTYP,"asynMotor")
 	field(VMAX,"$(VMAX)")
 	field(VBAS,"0")

--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -28,7 +28,7 @@
 record(scalcout, "$(P):$(M):MANAGERMODE")
 {
     field(ASG, "READONLY")
-    field(DESC, "Non-zero if manager is required for this IOC")
+    field(DESC, "Non-zero if manager is required for this axis")
     field(PINI, "YES")
     field(INPA, "$(PVPREFIX)CS:MANAGER CP")
     field(BB, "$(ASG)")


### PR DESCRIPTION
### Description of work

Adds access security to the GALIL ioc.

To test it, add the following line to globals.txt:

```
GALIL_01__ASG01=MANAGER
```

That will set up access security on galil 1, motor 1.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2789

### Acceptance criteria

- Access security is set up on galil, as per https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-access-security