### PR TITLE
Ticket 2961: Don't change acceleration when homing

### DIFF
--- a/GalilSup/Db/galil_Home_FIneg.gmc
+++ b/GalilSup/Db/galil_Home_FIneg.gmc
@@ -14,19 +14,16 @@ IF (home${AXIS}=1)
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=1) & (home${AXIS}=1))
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*-1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2
 	ENDIF
 	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=10))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		PR${AXIS}=((@ABS[hjgsp${AXIS}])*-2)
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*0.1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=4

--- a/GalilSup/Db/galil_Home_FIpos.gmc
+++ b/GalilSup/Db/galil_Home_FIpos.gmc
@@ -14,19 +14,16 @@ IF (home${AXIS}=1)
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=1) & (home${AXIS}=1))
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2
 	ENDIF
 	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=10))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		PR${AXIS}=((@ABS[hjgsp${AXIS}])*2)
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*-0.1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=4

--- a/GalilSup/Db/galil_Home_ForwLimit+FIneg.gmc
+++ b/GalilSup/Db/galil_Home_ForwLimit+FIneg.gmc
@@ -15,7 +15,6 @@ IF (home${AXIS}=1)
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_LF${AXIS}<>0))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=(@ABS[hjgsp${AXIS}])
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2
@@ -24,19 +23,16 @@ IF (home${AXIS}=1)
         hjog${AXIS}=2
     ENDIF
 	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_LF${AXIS}=0))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*-1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=10))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		PR${AXIS}=((@ABS[hjgsp${AXIS}])*-2)
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*0.1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Home_ForwLimit.gmc
+++ b/GalilSup/Db/galil_Home_ForwLimit.gmc
@@ -14,7 +14,6 @@ IF ((home${AXIS}=1))
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (_LF${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS};
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]*-1
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=2
@@ -27,13 +26,11 @@ IF ((home${AXIS}=1))
 		hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (_LF${AXIS}=1) & (home${AXIS}=1))
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (_LF${AXIS}=0) & (home${AXIS}=1))
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]/-10
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Home_ForwLimit_Home.gmc
+++ b/GalilSup/Db/galil_Home_ForwLimit_Home.gmc
@@ -14,7 +14,6 @@ IF ((home${AXIS}=1))
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (_LF${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS};
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]*-1
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=2
@@ -27,14 +26,12 @@ IF ((home${AXIS}=1))
 		hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (_LF${AXIS}=1) & (home${AXIS}=1))
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		SP${AXIS}=(@ABS[hjgsp${AXIS}])
 		HM${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Home_Home+FIneg.gmc
+++ b/GalilSup/Db/galil_Home_Home+FIneg.gmc
@@ -15,25 +15,21 @@ IF (home${AXIS}=1)
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		SP${AXIS}=(@ABS[hjgsp${AXIS}])
 		FE${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2
 	ENDIF
 	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=9))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*-1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=10))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		PR${AXIS}=((@ABS[hjgsp${AXIS}])*-2)
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*0.1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Home_Home+FIpos.gmc
+++ b/GalilSup/Db/galil_Home_Home+FIpos.gmc
@@ -15,25 +15,21 @@ IF (home${AXIS}=1)
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		SP${AXIS}=(@ABS[hjgsp${AXIS}])
 		FE${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2
 	ENDIF
 	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=9))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=10))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		PR${AXIS}=((@ABS[hjgsp${AXIS}])*2)
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*-0.1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Home_Home.gmc
+++ b/GalilSup/Db/galil_Home_Home.gmc
@@ -14,7 +14,6 @@ IF (home${AXIS}=1)
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		SP${AXIS}=(@ABS[hjgsp${AXIS}])
 		HM${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2

--- a/GalilSup/Db/galil_Home_RevLimit+FIpos.gmc
+++ b/GalilSup/Db/galil_Home_RevLimit+FIpos.gmc
@@ -15,7 +15,6 @@ IF (home${AXIS}=1)
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_LR${AXIS}<>0))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*-1)
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2
@@ -24,19 +23,16 @@ IF (home${AXIS}=1)
         hjog${AXIS}=2
     ENDIF
 	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_LR${AXIS}=0))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=10))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		PR${AXIS}=((@ABS[hjgsp${AXIS}])*2)
 		SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=1))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		JG${AXIS}=((@ABS[hjgsp${AXIS}])*-0.1)
 		FI${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Home_RevLimit.gmc
+++ b/GalilSup/Db/galil_Home_RevLimit.gmc
@@ -14,7 +14,6 @@ IF ((home${AXIS}=1))
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (_LR${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS};
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=2
@@ -27,13 +26,11 @@ IF ((home${AXIS}=1))
 		hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (_LR${AXIS}=1) & (home${AXIS}=1))
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]*-1
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (_LR${AXIS}=0) & (home${AXIS}=1))
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]/10
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Home_RevLimit_Home.gmc
+++ b/GalilSup/Db/galil_Home_RevLimit_Home.gmc
@@ -14,7 +14,6 @@ IF ((home${AXIS}=1))
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (_LR${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS};
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=2
@@ -27,14 +26,12 @@ IF ((home${AXIS}=1))
 		hjog${AXIS}=3
 	ENDIF
 	IF ((hjog${AXIS}=3) & (_BG${AXIS}=0) & (_LR${AXIS}=1) & (home${AXIS}=1))
-		AC${AXIS}=@ABS[hjgdc${AXIS}]
 		DC${AXIS}=@ABS[hjgdc${AXIS}]
 		JG${AXIS}=@ABS[hjgsp${AXIS}]*-1
 		SH${AXIS};WT50;BG${AXIS};hjog${AXIS}=4
 	ENDIF
 	IF ((hjog${AXIS}=4) & (_BG${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])
 		SP${AXIS}=(@ABS[hjgsp${AXIS}])
 		HM${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=5

--- a/GalilSup/Db/galil_Piezo_Home.gmc
+++ b/GalilSup/Db/galil_Piezo_Home.gmc
@@ -14,13 +14,11 @@ IF ((home${AXIS}=1))
 		ST${AXIS};ENDIF
 	IF ((hjog${AXIS}=1) & (_BG${AXIS}=0) & (home${AXIS}=1))
 		oldecel${AXIS}=_DC${AXIS};speed${AXIS}=_SP${AXIS}
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])*2
 		SP${AXIS}=(@ABS[hjgsp${AXIS}])
 		FE${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=2
 	ENDIF
 	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=9))
-		AC${AXIS}=(@ABS[hjgdc${AXIS}])
 		DC${AXIS}=(@ABS[hjgdc${AXIS}])*2
 		SP${AXIS}=(@ABS[hjgsp${AXIS}])/20
 		FE${AXIS};SH${AXIS};WT100;BG${AXIS};hjog${AXIS}=3


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/2961 for how to test.

The underlying issue was that the Galil driver passes homing routines a large deceleration so that it can stop quickly if it hits a limit. We were also using this as an acceleration value, which was too high. The acceleration set by the driver before the home routine is fine.