### PR TITLE
Potential fix for repeated homing?

### DIFF
--- a/GalilSup/src/GalilController.cpp
+++ b/GalilSup/src/GalilController.cpp
@@ -2660,7 +2660,7 @@ void GalilController::processUnsolicitedMesgs(void)
             //Homed is not part of Galil data record, we support it using Galil code and unsolicited messages over tcp instead
             //We must use asynMotorAxis version of setIntegerParam to set MSTA bits for this MotorAxis
             pAxis->setIntegerParam(motorStatusHomed_, value);
-            callParamCallbacks();
+            pAxis->callParamCallbacks();
             }
 
          //Motor homing status message
@@ -2759,6 +2759,7 @@ void GalilController::getStatus(void)
 					setIntegerParam(0, profileCurrentPoint_, (int)gco_->sourceValue(recdata_, src));
 					}
 				}
+			callParamCallbacks();
 			}
 		}
 	catch (string e) 


### PR DESCRIPTION
The homed flag is set on the axis motor status, but the params callback
for the controller is used which will be for axis A so there may be some
delay in other axes updating? Bit of a guess, not sure why you would
only see an issue with multiple simultaneous homes though.

See ISISComputingGroup/IBEX#3552
