### PR TITLE
Don't start home if already homing

### DIFF
--- a/GalilSup/src/GalilAxis.cpp
+++ b/GalilSup/src/GalilAxis.cpp
@@ -1466,7 +1466,7 @@ void GalilAxis::pollServices(void)
 
                          //Do jog after home move
                          if (!status && jah)
-                            {
+                         {
                             //Calculate position, velocity (velo not hvel) and acceleration
                             velocity = velo/mres;
                             acceleration = velocity/accl;
@@ -1477,8 +1477,11 @@ void GalilAxis::pollServices(void)
                                readback = encoder_position_;
                             //Do the move
                             if (position != readback)
+							{
+						        errlogSevPrintf(errlogInfo, "Poll services: jogging %c after home to raw position %.0f\n", axisName_, position);
                             	move(position, 0, 0, velocity, acceleration);
-                            }
+							}
+                         }
 
                          //Homed pollService completed
                          homedExecuted_ = true;


### PR DESCRIPTION
Check if we are already homing and don;t start a new one. Might workaround the issue reported in ISISComputingGroup/IBEX#3777 and ISISComputingGroup/IBEX#3552 