### PR TITLE
Add precision required for newer EPICS calc module

### DIFF
--- a/GalilSup/Db/galil_motor.template
+++ b/GalilSup/Db/galil_motor.template
@@ -101,4 +101,38 @@ record(bo,"$(P):$(M)_lock") {
   field(ONAM,"Locked")
 }
 
+
+#Required for motor record 6-10 and up
+#Below records are used to extract data from MR
+#and pass to driver
+# Motor direction for this axis
+record(longout,"$(P):$(M)Direction") {
+    field(DESC, "$(M) direction")
+    field(DOL,  "$(P):$(M).DIR CP MS")
+    field(OMSL, "closed_loop")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_DIRECTION")
+}
+
+
+# Motor offset for this axis
+record(ao,"$(P):$(M)Offset") {
+    field(DESC, "$(M) offset")
+    field(DOL,  "$(P):$(M).OFF CP MS")
+    field(OMSL, "closed_loop")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_OFFSET")
+    field(PREC, "$(PREC)")
+}
+
+# Motor resolution for this axis
+record(ao,"$(P):$(M)Resolution") {
+    field(DESC, "$(M) resolution")
+    field(DOL,  "$(P):$(M).MRES CP MS")
+    field(OMSL, "closed_loop")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_RESOLUTION")
+    field(PREC, "$(PREC)")
+}
+
 # end

--- a/GalilSup/Db/galil_motor_extras.template
+++ b/GalilSup/Db/galil_motor_extras.template
@@ -36,6 +36,39 @@ record(scalcout, "$(P):$(M):MANAGERMODE")
     field(OOPT, "Every Time")
 }
 
+#Required for motor record 6-10 and up
+#Below records are used to extract data from MR
+#and pass to driver
+# Motor direction for this axis
+record(longout,"$(P):$(M)Direction") {
+    field(DESC, "$(M) direction")
+    field(DOL,  "$(P):$(M).DIR CP MS")
+    field(OMSL, "closed_loop")
+    field(DTYP, "asynInt32")
+    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_DIRECTION")
+}
+
+
+# Motor offset for this axis
+record(ao,"$(P):$(M)Offset") {
+    field(DESC, "$(M) offset")
+    field(DOL,  "$(P):$(M).OFF CP MS")
+    field(OMSL, "closed_loop")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_OFFSET")
+    field(PREC, "$(PREC)")
+}
+
+# Motor resolution for this axis
+record(ao,"$(P):$(M)Resolution") {
+    field(DESC, "$(M) resolution")
+    field(DOL,  "$(P):$(M).MRES CP MS")
+    field(OMSL, "closed_loop")
+    field(DTYP, "asynFloat64")
+    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_RESOLUTION")
+    field(PREC, "$(PREC)")
+}
+
 #Below records are used to extract data from MR
 #and pass to driver
 record(ao,"$(P):$(M)_ACCL_SP") {

--- a/GalilSup/Db/galil_motor_extras.template
+++ b/GalilSup/Db/galil_motor_extras.template
@@ -36,39 +36,6 @@ record(scalcout, "$(P):$(M):MANAGERMODE")
     field(OOPT, "Every Time")
 }
 
-#Required for motor record 6-10 and up
-#Below records are used to extract data from MR
-#and pass to driver
-# Motor direction for this axis
-record(longout,"$(P):$(M)Direction") {
-    field(DESC, "$(M) direction")
-    field(DOL,  "$(P):$(M).DIR CP MS")
-    field(OMSL, "closed_loop")
-    field(DTYP, "asynInt32")
-    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_DIRECTION")
-}
-
-
-# Motor offset for this axis
-record(ao,"$(P):$(M)Offset") {
-    field(DESC, "$(M) offset")
-    field(DOL,  "$(P):$(M).OFF CP MS")
-    field(OMSL, "closed_loop")
-    field(DTYP, "asynFloat64")
-    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_OFFSET")
-    field(PREC, "$(PREC)")
-}
-
-# Motor resolution for this axis
-record(ao,"$(P):$(M)Resolution") {
-    field(DESC, "$(M) resolution")
-    field(DOL,  "$(P):$(M).MRES CP MS")
-    field(OMSL, "closed_loop")
-    field(DTYP, "asynFloat64")
-    field(OUT,  "@asyn($(PORT),$(ADDR))MOTOR_REC_RESOLUTION")
-    field(PREC, "$(PREC)")
-}
-
 #Below records are used to extract data from MR
 #and pass to driver
 record(ao,"$(P):$(M)_ACCL_SP") {

--- a/GalilSup/src/GalilCSAxis.cpp
+++ b/GalilSup/src/GalilCSAxis.cpp
@@ -379,6 +379,7 @@ asynStatus GalilCSAxis::doCalc(const char *expr, double args[], double *result) 
     /* Evaluate expression, return result */
     unsigned char rpn[512];	//Expression is converted to reverse polish notation 
     short err;
+    int precision = 12;         //Hard code precision for now
     
     *result = 0.0;
 
@@ -387,7 +388,7 @@ asynStatus GalilCSAxis::doCalc(const char *expr, double args[], double *result) 
 	printf("sCalcPostfix error in expression %s \n", expr);
 	return asynError;
     } else 
-	if (sCalcPerform(args, SCALCARGS, NULL, 0, result, NULL, 0, rpn) && finite(*result)) {
+	if (sCalcPerform(args, SCALCARGS, NULL, 0, result, NULL, 0, rpn, precision) && finite(*result)) {
 	    printf("calcPerform: error evaluating '%s'", expr);
 	    return asynError;
     }


### PR DESCRIPTION
### Description of work

Minor changes for EPICS 7 compatibility, add precision required for newer EPICS calc module

### To test

See ISISComputingGroup/IBEX#4599

### Acceptance criteria

* System builds with existing EPICS 3.15 
