### PR TITLE
Ticket5602 guides and apertures homing

### DIFF
--- a/GalilSup/Db/Makefile
+++ b/GalilSup/Db/Makefile
@@ -41,6 +41,8 @@ GMC += galil_Home_FIpos.gmc galil_Home_FIneg.gmc
 # Device specific routines
 GMC += galil_Oscillating_Collimator.gmc galil_Oscillating_Collimator_Merlin.gmc galil_Muon_Slits.gmc galil_emma_chopper_lifter.gmc
 GMC += galil_Home_sans2d_rear_detector.gmc
+GMC += galil_Home_sans2d_aperture.gmc
+GMC += galil_Home_sans2d_waveguides.gmc
 # Dummy routines mainly used for testing
 GMC += galil_Home_Dummy_Do_Nothing.gmc galil_Home_Dummy_Power_Light.gmc galil_Home_No_Home.gmc
 

--- a/GalilSup/Db/galil_Home_sans2d_aperture.gmc
+++ b/GalilSup/Db/galil_Home_sans2d_aperture.gmc
@@ -1,0 +1,67 @@
+NO*****************AXIS ${AXIS}********************
+NO*********HOME - Home Switch************
+#HOME${AXIS}
+IF (home${AXIS}=1)
+    inhome${AXIS}=1
+	IF ((home${AXIS}=1) & (hjog${AXIS}=0))
+	    slimfl${AXIS}=_FL${AXIS};FL${AXIS}=2147483647
+		slimbl${AXIS}=_BL${AXIS};BL${AXIS}=-2147483648
+		hjog${AXIS}=1
+	ENDIF
+	IF ((_LR${AXIS}=0) & (_LF${AXIS}=0) & (home${AXIS}=1))
+		home${AXIS}=0;MG "home${AXIS}", home${AXIS};ENDIF
+	IF ((hjog${AXIS}=1) & (_BG${AXIS}=1) & (home${AXIS}=1))
+		ST${AXIS};ENDIF
+        
+    g_hmst${AXIS}=1
+    
+    speed${AXIS}=_SP${AXIS}
+    oldecel${AXIS}=_DC${AXIS};
+    
+    AC${AXIS}=4096;DC${AXIS}=4096
+    SP${AXIS}=4096
+    JG${AXIS}=4096
+    SH${AXIS}
+    WT200
+    JP #Axis${AXIS}Hm2,(_LFA=0)
+    BG${AXIS}
+    AM${AXIS}
+    WT200
+    #Axis${AXIS}Hm2
+    JG${AXIS}=-4096
+    FI${AXIS}
+    BG${AXIS}
+    MC${AXIS}
+    WT200
+    PR${AXIS}=1000
+    BG${AXIS}
+    MC${AXIS}
+    WT200
+    JG${AXIS}=-100
+    FI${AXIS}
+    BG${AXIS}
+    MC${AXIS}
+    WT200
+    IF (_SC${AXIS}=10)
+        g_hmst${AXIS}=100
+    ENDIF
+    
+    SP${AXIS}=speed${AXIS}
+    DC${AXIS}=oldecel${AXIS}
+    hjog${AXIS}=2
+    
+	IF ((hjog${AXIS}=2) & (_BG${AXIS}=0) & (home${AXIS}=1) & (_SC${AXIS}=10))
+		hjog${AXIS}=0;home${AXIS}=0;homed${AXIS}=1
+		MG "home${AXIS}", home${AXIS};MG "homed${AXIS}", homed${AXIS}
+	ENDIF
+ELSE
+	hjog${AXIS}=0
+ENDIF
+IF ((home${AXIS}=0) & (inhome${AXIS}=1))
+    FL${AXIS}=slimfl${AXIS}
+	BL${AXIS}=slimbl${AXIS}
+	inhome${AXIS}=0
+ENDIF
+IF (mlock=1)
+	II ,,dpon,dvalues
+ENDIF

--- a/GalilSup/Db/galil_Home_sans2d_waveguides.gmc
+++ b/GalilSup/Db/galil_Home_sans2d_waveguides.gmc
@@ -1,5 +1,5 @@
 NO*****************AXIS ${AXIS}********************
-NO*********HOME - sans2d apertures ************
+NO*********HOME - sans2d waveguides************
 #HOME${AXIS}
 IF (home${AXIS}=1)
     inhome${AXIS}=1
@@ -19,33 +19,49 @@ IF (home${AXIS}=1)
     oldecel${AXIS}=_DC${AXIS};
     olacel${AXIS}=_AC${AXIS};
     
-    AC${AXIS}=4096;DC${AXIS}=4096
-    SP${AXIS}=4096
-    JG${AXIS}=4096
+    AC${AXIS}=1024
+    DC${AXIS}=1024
+    SP${AXIS}=-256
+    JG${AXIS}=-256
+    JP #Axis${AXIS}Hm2,(_LR${AXIS}=0)
+    WT1000
     SH${AXIS}
-    WT200
-    JP #Axis${AXIS}Hm2,(_LFA=0)
+    WT1000
     BG${AXIS}
     AM${AXIS}
-    WT200
     #Axis${AXIS}Hm2
-    JG${AXIS}=-4096
+    WT1000
+    SP${AXIS}=256
+    JG${AXIS}=256
+    WT2000
+    SH${AXIS}
+    WT1000
     FI${AXIS}
     BG${AXIS}
-    MC${AXIS}
-    WT200
-    PR${AXIS}=1000
+    AM${AXIS}
+    WT1000
+    SP${AXIS}=128
+    JG${AXIS}=128
+    PR${AXIS}=400
+    WT1500
+    SH${AXIS}
+    WT1500
     BG${AXIS}
-    MC${AXIS}
-    WT200
-    JG${AXIS}=-100
+    AM${AXIS}
+    WT1500
+    SP${AXIS}=-20
+    JG${AXIS}=-20
+    WT2000
+    SH${AXIS}
+    WT1000
     FI${AXIS}
     BG${AXIS}
-    MC${AXIS}
-    WT200
+    AM${AXIS}
+    WT1500
     IF (_SC${AXIS}=10)
         g_hmst${AXIS}=100
     ENDIF
+    MOA
     
     SP${AXIS}=speed${AXIS}
     DC${AXIS}=oldecel${AXIS}


### PR DESCRIPTION
For ticket https://github.com/ISISComputingGroup/IBEX/issues/5602

For apertures, home is:
- Move all the way onto forward limit (skip if already parked on limit)
- Find index in negative direction at a speed of `-4096`
- Position relative +1000 encoder counts
- Find index in negative direction at speed of `-100`

Annotated galil code for apertures (in case it is useful for the reviewer):

```
#Ap0Hm
g_hmstA=1
ACA=4096;DCA=4096  ' Acceleration and decelleration
SPA=4096           ' Set slew speed
JGA=4096           ' Set jog speed
SHA                ' Enable motor
WT200              ' Wait 200ms
JP #Ap0Hm2,(_LFA=0)' Jump to Ap0Hm2 if forward limit = 0 (presumably active - i.e. motor already on limit) 
BGA                ' Begin motion
AMA                ' Wait for motion to complete
WT200              ' wait 200ms
#Ap0Hm2
JGA=-4096          ' Set jog speed (negative dir)
FIA                ' Find index
BGA                ' Begin motion
MCA                ' Wait for motion to complete
WT200              ' Wait 200ms
PRA=1000           ' Position relative +1000 encoder counts
BGA                ' Begin motion
MCA                ' Wait for motion to complete
WT200              ' Wait 200ms
JGA=-100           ' Set jog speed (very slow, negative dir)
FIA                ' Find index
BGA                ' Begin motion
MCA                ' Wait for motion complete
WT200
IF (_SCA=10)
g_hmstA=100
ENDIF
EN
```

I think this is closest to `galil_Home_Home+FIneg.gmc` but not exactly the same (e.g. speeds are set at 10% for later move, whereas for apertures it is ~2.5%). Therefore I have ported the existing SECI routine into IBEX

For waveguides, home is not similar to any of our existing homing routines. There are long waits between many of the statements which I suspect are there due to some quirk of the hardware. It also does `MO` (motor off) after homing which is non-standard (as far as I can tell). Therefore these have been ported into IBEX as-is.

The galil command reference is available at `//isis/shares/ISIS_Experiment_Controls/Manuals/Galil/DMC2280/manc2xxx.pdf` if you need to double-check what any of the commands do.