### PR TITLE
Remove gmc from makefile that is no longer present

### DIFF
--- a/GalilSup/Db/Makefile
+++ b/GalilSup/Db/Makefile
@@ -43,6 +43,8 @@ GMC += galil_Oscillating_Collimator.gmc galil_Oscillating_Collimator_Merlin.gmc 
 GMC += galil_Home_sans2d_rear_detector.gmc
 GMC += galil_sans2d_front_det_limit_footer.gmc
 GMC += galil_sans2d_rear_det_limit_footer.gmc
+GMC += galil_Home_RevLimit+FIpos_sans2d_guides.gmc
+GMC += galil_Home_ForwLimit+FIneg_sans2d_apertures.gmc
 
 # Dummy routines mainly used for testing
 GMC += galil_Home_Dummy_Do_Nothing.gmc galil_Home_Dummy_Power_Light.gmc galil_Home_No_Home.gmc

--- a/GalilSup/Db/Makefile
+++ b/GalilSup/Db/Makefile
@@ -41,8 +41,6 @@ GMC += galil_Home_FIpos.gmc galil_Home_FIneg.gmc
 # Device specific routines
 GMC += galil_Oscillating_Collimator.gmc galil_Oscillating_Collimator_Merlin.gmc galil_Muon_Slits.gmc galil_emma_chopper_lifter.gmc
 GMC += galil_Home_sans2d_rear_detector.gmc
-GMC += galil_Home_sans2d_aperture.gmc
-GMC += galil_Home_sans2d_waveguides.gmc
 GMC += galil_sans2d_front_det_limit_footer.gmc
 GMC += galil_sans2d_rear_det_limit_footer.gmc
 


### PR DESCRIPTION
The make of the galil support module was failing because it expected to find gmc files that were removed in https://github.com/ISISComputingGroup/EPICS-galil/commit/e6bc74debb7609cba59ff7407c50b0888d3f456a#diff-e3629f06311266cc3b63014c7a4d151a9ae874fb9ac3e6359837fde2bf3f11f9. This removes them from the makefile.