### PR TITLE
Protect poll

### DIFF
--- a/GalilSup/src/GalilController.h
+++ b/GalilSup/src/GalilController.h
@@ -371,6 +371,7 @@ private:
   void stopAxes();
   int quiet_start_;
   epicsEvent motion_started_;
+  epicsMutex pollLock_;
 
 					//Stores the motor enable disable interlock digital IO setup, only first 8 digital in ports supported
   struct Galilmotor_enables motor_enables_[8];


### PR DESCRIPTION
* Check for mres = 0.0. on motor change
* Add additional lock around poll - it seems it can get called from multiple places (one being indirectly from motor record poll) 

See ISISComputingGroup/IBEX#6390
