### PR TITLE
Set JAH_CMD to 0 as we don't want to jog after home generally

### DIFF
--- a/GalilSup/Db/galil_motor_extras.template
+++ b/GalilSup/Db/galil_motor_extras.template
@@ -249,7 +249,7 @@ record(bo,"$(P)$(M)_JAH_CMD")
 {
 	field(DESC,"Jog after home")
 	field(DTYP,"asynInt32")
-	field(VAL, "1")
+	field(VAL, "0")
 	field(PINI,"YES")
 	field(ZNAM,"No")
 	field(ZSV, "NO_ALARM")


### PR DESCRIPTION
Updated to match the default we decided upon in https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Galil-default-parameters.

The value is autosaved and so this shouldn't affect running instruments, only new axes