### PR TITLE
Protect MRES and ERES back put

### DIFF
--- a/GalilSup/Db/galil_motor_extras.template
+++ b/GalilSup/Db/galil_motor_extras.template
@@ -1705,6 +1705,7 @@ record(calcout, "$(P)$(M):INV_MRES:SP_CALC")
 	field(INPA, "$(P)$(M):INV_MRES")
 	field(CALC, "1/A")
 	field(OUT, "$(P)$(M).MRES")
+	field(SDIS, "$(P)$(M):INV_MRES_CALC.PACT")
 	field(OOPT, "On Change")
 }
 
@@ -1728,6 +1729,7 @@ record(calcout, "$(P)$(M):INV_ERES:SP_CALC")
 	field(INPA, "$(P)$(M):INV_ERES")
 	field(CALC, "1/A")
 	field(OUT, "$(P)$(M).ERES")
+	field(SDIS, "$(P)$(M):INV_ERES_CALC.PACT")
 	field(OOPT, "On Change")
 }
 


### PR DESCRIPTION
Protect potential extra bounce when setting MRES, this may be (one of) the cause of ISISComputingGroup/IBEX#6881
