### PR TITLE
Add precision to motor encoder drift PV

### DIFF
--- a/GalilSup/Db/galil_motor_extras.template
+++ b/GalilSup/Db/galil_motor_extras.template
@@ -1627,6 +1627,7 @@ record(ai,"$(P)$(M)_MTRENC_DRIFT")
 {
     field(DESC, "Encoder motor drift")
     field(EGU, "$(EGU)")
+	field(PREC, 4)
     info(archive, "VAL")
 }
 


### PR DESCRIPTION
Due to lack of precision, it sometimes appears that there is no motor drift between encoder and motors. This should hopefully help resolve this issue that was observed on OFFSPEC recently. 