### PR TITLE
Try to avoid race condition on startup

### DIFF
--- a/GalilSup/Db/galil_ctrl_extras.template
+++ b/GalilSup/Db/galil_ctrl_extras.template
@@ -435,7 +435,11 @@ record(ao,"$(P):PWRDET:SP") {
     field(DTYP, "asynFloat64")
     field(OUT, "@asyn($(PORT),0)USER_VAR pwrdet")
 	field(SCAN, "Passive")
+    # set a default non-zero as zero in galil is a problem
+    # and is never a test value
+    field(VAL, "2")
     info(autosaveFields_pass0, "VAL")
+    info(archive, "VAL")
 }
 
 record(ai,"$(P):PWRDET") {
@@ -443,7 +447,9 @@ record(ai,"$(P):PWRDET") {
     field(DTYP, "asynFloat64")
     field(INP,  "@asyn($(PORT),0)USER_VAR pwrdet")
 	field(SCAN, "10 second")
+    field(SDIS, "$(P):PWRDET:SP.PACT")
 	field(FLNK, "$(P):PWRDET:ALERT.PROC")
+    info(archive, "VAL")
 }
 
 ## 0 = ok, 1 = problem
@@ -454,7 +460,7 @@ record(calcout,"$(P):PWRDET:ALERT") {
 	field(INPB, "$(P):PWRDET:SP")
 	field(CALC, "A!=B")
 	field(OOPT, "When Zero")
-	field(OUT, "$(P):PWRDET:TIMER.PROC")
+	field(OUT, "$(P):PWRDET:TIMER.PROC PP")
     info(archive, "VAL")
 }
 
@@ -466,12 +472,16 @@ record(bo,"$(P):PWRDET:RESET:SP") {
 }
 
 ## how often we should set a new test value
-## A % 360 means 3600 seconds as we are on 10 second scan link
+## A = 360 means 3600 seconds as we are on 10 second scan link
+## Changing value is only a check in case it got saved into galil
+## firmware so changing this once per ioc run is fine 
+## make sure we don't set a new value too soon
+## after ioc startup in case of a quick restart causing a race condition 
 record(calcout, "$(P):PWRDET:TIMER") {
 	field(DESC, "Set new PWRDET test value")
-	field(CALC, "A % 360; A := A + 1")
+	field(CALC, "A = 360; A := A + 1")
 	field(INPA, "0")
-	field(OOPT, "When Zero")
+	field(OOPT, "When Non-zero")
 	field(DOPT, "Use OCAL")
 	field(OCAL, "CEIL(RNDM*100)+1")
 	field(OUT, "$(P):PWRDET:SP PP")


### PR DESCRIPTION
Try and avoid what looks like a race condition on startup - previously it would try and change the number quite soon after ioc start, change this so it does it after its usual periodic period, but now also stop the repeated resets as they are not needed.  Also add an `SDIS` to read so it doesn't queue at same time as a write, but chance of that causing an issue were quite small.  

There is still a small window of an issue - currently it autosaves as if it were a position, so within 5 seconds of a change. So there is a 5 second window when it does that one and only change that if the ioc were to restart it would flag an error. We could change to an autosave triggered set if we feel this is an issue.    

Will need apply to new galil driver too, will do that post review 